### PR TITLE
fix(lab01/ex03): correct republish flow and prompt editing steps

### DIFF
--- a/Instructions/Labs/01-Build-your-first-declarative-agent/03-add-starter-prompts.md
+++ b/Instructions/Labs/01-Build-your-first-declarative-agent/03-add-starter-prompts.md
@@ -18,8 +18,8 @@ This exercise should take approximately **10** minutes to complete.
 In Copilot Studio:
 
 1. Navigate to your **Product Support** agent's **Overview** page.
-1. Note that the conversational agent creation wizard generated suggested prompts for your agent during creation. Let's replace these with more appropriate prompts based on the agent's capabilities.
-1. In the **Suggested Prompts** section, select the **Edit** icon.
+1. Note that the conversational agent creation wizard may generate suggested prompts for your agent during creation. If it does, you can replace these with more appropriate prompts based on the agent's capabilities.
+1. In the **Suggested Prompts** section, select the **Edit** icon or the **Add suggested prompts** button, depending on whether or not prompts were generated during agent creation.
 1. Replace the existing prompts with the following:
 
       `Eagle Air` : `Tell me about Eagle Air`
@@ -45,13 +45,16 @@ Let's publish the updated agent to Microsoft 365 Copilot.
 1. On the **Availability options** window that opens, select **Copy** under the **Share link** heading.
 
     ![Screenshot of the Availability options window.](../Media/availability-options-share-link.png)
-1. In a different tab of your web browser, **paste** your agent's share link and select **enter**. A window appears describing the **Product Support** agent.
-1. Select **Update now** under the agent's name to publish the changes to the Product Support agent. Wait a few moments while the agent is updated.
-1. When the update is complete, close the modal window. If you're not taken to Microsoft 365 Copilot in your browser, select **Copilot** from the left-hand menu or the **Apps** menu in the Microsoft 365 portal.
+1. In a different tab of your web browser, **paste** your agent's share link and press **Enter**. A window appears describing the **Product Support** agent.
+1. Wait a few moments while the changes are published to the Product Support agent.
+1. When the update is complete, close the modal window If you're not taken to Microsoft 365 Copilot in your browser, select **Copilot** from the left-hand menu or the **Apps** menu in the Microsoft 365 portal.
 
 ## Test your agent in Microsoft 365 Copilot
 
 1. In the side panel in **Microsoft 365 Copilot**, find **Product Support** in the list of agents and select it to enter the immersive experience to chat directly with the agent. Notice that the suggested prompts you defined in Copilot Studio display in the user interface.
 
     ![Screenshot of Microsoft 365 Copilot in Microsoft Edge showing the Product Support agent's starter prompts.](../Media/product-support-starter-prompts.png)
+
+    > [!NOTE]
+    > It can take several minutes for newly published suggested prompts to appear in Microsoft 365 Copilot. If you don't see them right away, wait a few minutes, then select **New chat** and reselect **Product Support**. The prompts display on a new, empty session.
 1. **Select** a suggested prompt, **send** the message, and review the response.

--- a/Instructions/Labs/01-Build-your-first-declarative-agent/03-add-starter-prompts.md
+++ b/Instructions/Labs/01-Build-your-first-declarative-agent/03-add-starter-prompts.md
@@ -47,7 +47,9 @@ Let's publish the updated agent to Microsoft 365 Copilot.
     ![Screenshot of the Availability options window.](../Media/availability-options-share-link.png)
 1. In a different tab of your web browser, **paste** your agent's share link and press **Enter**. A window appears describing the **Product Support** agent.
 1. Wait a few moments while the changes are published to the Product Support agent.
-1. When the update is complete, close the modal window If you're not taken to Microsoft 365 Copilot in your browser, select **Copilot** from the left-hand menu or the **Apps** menu in the Microsoft 365 portal.
+   > [!NOTE]
+   > It can take several minutes for newly published suggested prompts to appear in Microsoft 365 Copilot. If you don't see them right away, wait a few minutes, then select **New chat** and reselect **Product Support**. The prompts display on a new, empty session.
+1. When the update is complete, return to Copilot Studio and close the modal window. If you're not taken to **Microsoft 365 Copilot** in your browser, go to **Microsoft 365 Copilot** using the **App Launcher** icon (grid icon) in the top-left of the page.
 
 ## Test your agent in Microsoft 365 Copilot
 
@@ -55,6 +57,4 @@ Let's publish the updated agent to Microsoft 365 Copilot.
 
     ![Screenshot of Microsoft 365 Copilot in Microsoft Edge showing the Product Support agent's starter prompts.](../Media/product-support-starter-prompts.png)
 
-    > [!NOTE]
-    > It can take several minutes for newly published suggested prompts to appear in Microsoft 365 Copilot. If you don't see them right away, wait a few minutes, then select **New chat** and reselect **Product Support**. The prompts display on a new, empty session.
-1. **Select** a suggested prompt, **send** the message, and review the response.
+1. Select a suggested prompt, send the message, and review the response.


### PR DESCRIPTION
## Summary

Corrects the publish and test instructions in Lab 01, Exercise 03 (Add suggested prompts) to match the current Copilot Studio and Microsoft 365 Copilot UI, and fixes wording and formatting issues.

## Changes

### Lab 01 — Exercise 03 (Add suggested prompts)

- Updated the suggested-prompts step to reflect that the creation wizard *may* generate prompts, and that you select either the **Edit** icon or the **Add suggested prompts** button depending on whether prompts already exist.
- Replaced the obsolete **Update now** publish step with the current flow that publishes changes automatically, and clarified the wait behavior.
- Corrected the navigation guidance after publishing to use the **App Launcher** icon to open **Microsoft 365 Copilot**, replacing the outdated **Copilot** left-hand menu / **Apps** menu reference.
- Moved the delayed-prompts `[!NOTE]` callout into the publish step where it is relevant.
- Fixed wording (`select **enter**` to `press **Enter**`) and removed bold emphasis from action verbs (**Select**/**send**) per Microsoft Learn style.

## Files changed

- `Instructions/Labs/01-Build-your-first-declarative-agent/03-add-starter-prompts.md` — updated prompt-editing, republish, and test steps for current UI and style compliance