### PR TITLE
fix(ms-4022): update SharePoint library steps and step spacing

### DIFF
--- a/Instructions/Labs/01-Build-your-first-declarative-agent/01-create-declarative-agent.md
+++ b/Instructions/Labs/01-Build-your-first-declarative-agent/01-create-declarative-agent.md
@@ -21,16 +21,23 @@ This exercise should take approximately **20** minutes to complete.
 Start by creating a new declarative agent in Copilot Studio. Use generative AI to draft the instructions and properties for the agent.
 
 1. In a web browser, navigate to [Microsoft Copilot Studio](https://copilotstudio.microsoft.com/) at `https://copilotstudio.microsoft.com`.
+
 1. Sign in using a work or school account where you have permission to create in Copilot Studio.
+
 1. If prompted to stay signed in, select **Yes**.
+
 1. If prompted, on the **Welcome to Microsoft Copilot Studio** page, select your country/region and then select **Get Started**.
+
 1. If you're presented with the **Welcome to Copilot Studio!** popup, select **Skip**.
+
 1. When you reach Copilot Studio, you'll likely start on the Home page for creating a new agent.
 
     ![Screenshot of the conversational interface for creating a custom agent.](../Media/copilot-start-screen.png)
 
 1. Navigate to **Agents** in the left side navigation panel.
+
 1. Select **Microsoft 365 Copilot** from the agents page.
+
 1. On the **Microsoft 365 Copilot** agent page, select **Add** within the **Agents** section.
 
     ![Screenshot of the Microsoft 365 Copilot agent page in Copilot Studio.](../Media/add-copilot-agent.png)
@@ -43,7 +50,9 @@ Start by creating a new declarative agent in Copilot Studio. Use generative AI t
 Next, configure the agent's properties and metadata manually to ensure consistent results for this exercise.
 
 1. In the **Name** field, enter `Product support`.
+
 1. In the **Description** field, enter `A product support agent that can answer queries about Contoso Electronics products`.
+
 1. In the **Instructions** text box, enter the following:
   
     ```md
@@ -54,6 +63,7 @@ Next, configure the agent's properties and metadata manually to ensure consisten
     ```
 
 1. Note that suggested prompts are generated using generative AI. Leave the **Suggested prompts** section empty for now. You will update these prompts in an upcoming exercise.
+
 1. Select **Create** at the top of the page to create the agent.  After a few moments, you are taken to the agent's overview page.
 
 ## Test the agent in Copilot Studio
@@ -65,7 +75,9 @@ Next, test the behavior of your agent in the test pane within Copilot Studio bef
     ![Screenshot of the Product Support agent page before publishing.](../Media/product-support-publish-details.png)
 
 1. If the **Test your agent** pane is not displayed to the right of the agent overview information, select the **Test** button next to the **Publish** button to open the test pane.
+
 1. In the prompt box within the test pane, enter `What can you do?` and submit your message.
+
 1. Wait for the response. Notice how the response starts with the text "Thanks for using a Copilot agent!" as instructed in the instructions you defined for the agent earlier.
 
     ![Screenshot of the test pane conversation with the product support agent.](../Media/product-support-test-pane.png)
@@ -85,15 +97,19 @@ Next, publish your agent to Microsoft 365 Copilot. From the **Product Support** 
 > The information on this form is used to populate the catalog entry in your organization's Office and Teams Catalogs and the Microsoft Admin Center Integrated Apps list. It isn't used by the Microsoft 365 Copilot language model to invoke your agent.
 
 1. In the **Short description** text box enter `Answers questions about Contoso Electronics products`, replacing the automatically generated content.
+
 1. Accept the default suggestions for the remaining fields.
+
 1. Select **Publish**.
     ![Screenshot of the Publish agent window before selecting the Publish button.](../Media/publish-window.png)
+
 1. Wait for the agent to be published.  Do not close the modal window during publishing. This may take a few minutes.
 
 > [!NOTE]
 > When you select **Publish**, a bot resource corresponding to your agent is provisioned in your tenant's Microsoft Entra ID environment. The resource allows users to interact with the agent in Microsoft Teams.
 
 1. Once the agent is published, the **Availability options** window appears.
+
 1. Under **Share link**, select **Copy** to copy the share link for your agent, then select **Done**.
 
     ![Screenshot of the Availability options window highlighting the Copy button.](../Media/share-link-copy.png)
@@ -108,6 +124,7 @@ Next, publish your agent to Microsoft 365 Copilot. From the **Product Support** 
     ![Screenshot of the modal window providing overview info for the Product Support agent before it's added to Microsoft 365 Copilot.](../Media/product-support-add-agent.png)
 
 1. Select **Add** to add your agent to Microsoft 365 Copilot.
+
 1. Wait for your agent to be added. Your agent is launched in Microsoft 365 Copilot.
 
 ## Test the agent in Microsoft 365 Copilot
@@ -119,6 +136,7 @@ Following the previous steps, you are currently in the **immersive** agent exper
 ![Screenshot of the immersive experience with the Product Support agent in Microsoft 365 Copilot.](../Media/product-support-immersive.png)
 
 1. In the prompt box, enter `What can you do?` and submit your message.
+
 1. Send the message and wait for the response. Notice how the response starts with the text "Thanks for using a Copilot agent!" following the guidance you provided in the agent's instructions.
 
     Continuing in the browser, let's test the **in-context** experience.

--- a/Instructions/Labs/01-Build-your-first-declarative-agent/02-add-custom-knowledge.md
+++ b/Instructions/Labs/01-Build-your-first-declarative-agent/02-add-custom-knowledge.md
@@ -34,33 +34,51 @@ Before you can start this exercise, you will need to upload the product-related 
 ### Create a SharePoint site
 
 1. In your web browser, navigate to [Microsoft 365 Copilot](https://m365.cloud.microsoft.com) at `https://m365.cloud.microsoft.com` and sign in with the Microsoft 365 account you're using for this lab. 
+
 1. Select the **App Launcher** icon (grid icon) in the top left corner of the page, then select **More Apps**.
     ![Screenshot of the M365 apps button in Copilot Chat.](../Media/apps-icon.png)
+
 1. Select **SharePoint** from the catalog of apps.
+
 1. Skip any messages about new features and navigate to the SharePoint homepage.
+
 1. From the left-navigation menu, select **Build**.
+
 1. Under the **Start building** section, select **Site**.
+
 1. Select **Team site** as the type of site.
+
 1. On the **Select a site template** page, under the **From Microsoft** section, select **Standard team**.
+
 1. On the **Preview site template** page, select **Use template**.
+
 1. On the **Give your site a name** page, enter `Product support`.
+
 > [!NOTE]
 > If the message **The site address is available with modification** appears, modify the site name until the message indicates that the site address is available. You can accept the suggested modification or create your own.
+
 1. Change the **Privacy settings** to **Public - anyone in the organization can access this site**.
+
 1. Select **Create site**. Creation of the site may take a few moments before the **Go to site** button is activated.
+
 1. Select **Go to site**. You're navigated to your new SharePoint site in the browser.
 
 ### Create a document library
 
-1. From the **Product support** SharePoint site, select the **Create** button at the top of the page then select **Document library**.
-1. On the **Create a new document library** page, select **Blank library**.
+1. From the **Product support** SharePoint site, select **+ New** at the top of the page then select **Document library**.
+
+1. On the **Create a new document library** page, under **Start from scratch or reuse**, select **Blank library**.
+
 1. In the **Name** field, enter `Products` then select **Create**. You're navigated to the new document library.
 
 ### Upload sample data
 
 1. From the **Products** library, select the **+ Create or upload** button then select **Files upload**.
+
 1. Navigate to the folder on your computer where you saved the sample files you downloaded in an earlier step.
+
 1. **Select all** of the files in your local Products folder and then select **Open** to upload them to SharePoint.
+
 1. Wait for the upload to complete. The files will now appear in the **Products** library in SharePoint.
 
 ### Copy the SharePoint URL
@@ -68,7 +86,9 @@ Before you can start this exercise, you will need to upload the product-related 
 Next, copy the direct URL to the site for use when configuring your agent's knowledge.
 
 1. From the **Products** library page in SharePoint, select the **Settings** icon in the top right and choose **Library settings** then **More library settings**.
+
 1. Locate the **Web address** property. Your **SharePoint site URL** is the portion of the Web address that is in the format `https://DOMAIN.sharepoint.com/sites/SITE_NAME/LIBRARY_NAME/Forms/AllItems.aspx`. Your URL should be in the format `https://DOMAIN.sharepoint.com/sites/ProductSupport/Products/Forms/AllItems.aspx`, where DOMAIN is your Microsoft 365 tenant domain.
+
 1. **Copy** your SharePoint site URL and save it for use in upcoming lab steps. Do not include any portion of the URL that comes after "/Products".
 
 ## Configure your agent with custom knowledge
@@ -78,15 +98,23 @@ Add the SharePoint URL to your agent as a grounding knowledge source.
 ### Add SharePoint URL
 
 1. In a web browser, navigate to [Microsoft Copilot Studio](https://copilotstudio.microsoft.com/) at `https://copilotstudio.microsoft.com`.
+
 1. Skip any messages about new features.
+
 1. Select **Agents**.
+
 1. Select the **Microsoft 365 Copilot** agent.
+
 1. Select your **Product Support** agent.
+
 1. From the **Knowledge** section of the agent overview page, select **Add Knowledge**.
+
 1. On the **Add knowledge** page of the wizard that opens, select **SharePoint**.
+
 1. In the text box, paste the URL of your **Products** SharePoint library, then select **Add**. This should be in the format: `https://DOMAIN.sharepoint.com/sites/ProductSupport/Products`.
 
 1. Select **Add to agent** then wait for the knowledge source to be added to the agent. This may take a minute.
+
 1. Notice that the **Products** library is listed under the **Knowledge** section of the agent's overview information.
 
     ![Screenshot of the Knowledge section of the Product Support agent, showing the Products library added to the agent.](../Media/agent-knowledge-products.png)
@@ -99,7 +127,9 @@ Add the SharePoint URL to your agent as a grounding knowledge source.
 Next, update the agent's instructions to describe how the agent should use the knowledge source.
 
 1. From the agent's overview page in Copilot Studio, select **Edit** within the **Details** section.
+
 1. Replace the contents of the **Instructions** text box with the following: `You are an agent tasked with answering questions about Contoso Electronics products. Start every response by enthusiastically thanking the user for their question or comment, then respond to their question or comment. You will use documents from the Products folder in SharePoint as your source of information. If you can't find the necessary information, you should suggest that the agent should reach out to the team responsible for further assistance. Your responses should be concise and always include a cited source.`
+
 1. Select **Save** in the **Details** section.
 
 ## Test your agent in Copilot Studio
@@ -107,19 +137,25 @@ Next, update the agent's instructions to describe how the agent should use the k
 Finally, test your agent's ability to use the custom knowledge source.
 
 1. From the **Test your agent** pane in your agent's overview page in Copilot Studio, select the **New chat** button to refresh the test pane.
+
 1. In the text box for the test conversation, enter `Tell me about Eagle Air` and send the message.
+
 1. Wait for the response. Notice that the response contains information about the Eagle Air drone. The response contains citations and references to the Eagle Air document stored in SharePoint.
 
    Let's try a few more prompts:
 
 1. In the message box, enter `Recommend a product suitable for a farmer` and send the message.
+
 1. Wait for the response. Notice that the response contains information about the Eagle Air and some extra context as to why the Eagle Air is recommended. The response contains citations and references to the Eagle Air document stored in SharePoint.
+
 1. In the message box, enter `Explain why the Eagle Air is more suitable than Contoso Quad` and send the message.
+
 1. Wait for the response. Notice that the response explains in more detail why the Eagle Air is more suitable than the Contoso Quad for use by farmers.
 
    Finally, let's test the fallback response by asking a question that the agent can't answer:
 
 1. In the message box, enter `When was Mark8 released?` and send the message.
+
 1. Wait for the response. Notice that the response suggests that the agent should reach out to the team responsible for further assistance as defined in the instructions.
 
     ![Screenshot of the agent's response in the test pane.](../Media/test-agent-knowledge.png)

--- a/Instructions/Labs/01-Build-your-first-declarative-agent/03-add-starter-prompts.md
+++ b/Instructions/Labs/01-Build-your-first-declarative-agent/03-add-starter-prompts.md
@@ -18,8 +18,11 @@ This exercise should take approximately **10** minutes to complete.
 In Copilot Studio:
 
 1. Navigate to your **Product Support** agent's **Overview** page.
+
 1. Note that the conversational agent creation wizard may generate suggested prompts for your agent during creation. If it does, you can replace these with more appropriate prompts based on the agent's capabilities.
+
 1. In the **Suggested Prompts** section, select the **Edit** icon or the **Add suggested prompts** button, depending on whether or not prompts were generated during agent creation.
+
 1. Replace the existing prompts with the following:
 
       `Eagle Air` : `Tell me about Eagle Air`
@@ -41,11 +44,15 @@ In Copilot Studio:
 Let's publish the updated agent to Microsoft 365 Copilot.
 
 1. After your agent's changes have been saved successfully, select **Publish** at the top-right of your agent's overview page in Copilot Studio.
+
 1. On the modal window that opens, select **Publish**.
+
 1. On the **Availability options** window that opens, select **Copy** under the **Share link** heading.
 
     ![Screenshot of the Availability options window.](../Media/availability-options-share-link.png)
+
 1. In a different tab of your web browser, **paste** your agent's share link and press **Enter**. A window appears describing the **Product Support** agent.
+
 1. Wait a few moments while the changes are published to the Product Support agent.
   
    > [!NOTE]

--- a/Instructions/Labs/02-Prompt-actions/01-create-prompt-action.md
+++ b/Instructions/Labs/02-Prompt-actions/01-create-prompt-action.md
@@ -16,14 +16,22 @@ This exercise should take approximately **15** minutes to complete.
 ## Create a custom prompt in Copilot Studio
 
 1. Open Copilot Studio in your web browser by navigating to [Copilot Studio](https://copilotstudio.microsoft.com) at `https://copilotstudio.microsoft.com`.
+
 1. Select **Tools** from the left navigation.
+
 1. Select **+ New tool**.
+
 1. On the **New tool** dialog box, select **Prompt**. You're taken to the prompt builder UI. Copilot is available within this window, but you'll define the prompt manually for this exercise.
+
 1. In the textbox at the top of the window, select the auto-generated name and replace it with the name `Marketing Pitch Prompt`.
+
 1. In the **Instructions** text box, enter `Create a marketing pitch for a product based on a `.
 1. Place your cursor at the end of the sentence you entered, then select **Add content**.
+
 1. Select **Text**.
+
 1. In the **Name** field, enter `Draft`.
+
 1. In the **Sample data** field, enter `The Mighty Mechanical Pencil is new, exciting, and useful. It's not only the first of its kind pencil, but it's fun to use.` then select **Close**.
 
     ![Screenshot of the prompt builder UI in Copilot Studio showing an input variable being configured with the name "Draft".](../Media/prompt-content-sample-data.png)
@@ -47,8 +55,10 @@ This exercise should take approximately **15** minutes to complete.
     ```
 
 1. Select **Test** again to retest the prompt.
+
 1. Notice how the response differs.
     ![Screenshot of the custom prompt UI after testing the refined prompt.](../Media/test-prompt-refined.png)
+
 1. Select **Save** to save the prompt.
 
 ## (Optional) Add a prompt action to an agent
@@ -58,13 +68,19 @@ If you've completed the previous lab and created a declarative agent, you may ad
 ### Add the prompt tool
 
 1. From the sidebar in Copilot Studio, select **Agents**.
+
 1. Select **Microsoft 365 Copilot**.
+
 1. Under **Agents**, select the **Product Support** agent you'd like to add the action to.
+
 1. From the **Tools** section of the page, select **Add tool**.
+
 1. Select the **Prompt** filter.
+
 1. Select the **Marketing Pitch Prompt** tool.
 
     ![Screenshot of the Add tool window listing the Marketing Pitch Prompt tool.](../Media/add-marketing-pitch-tool.png)
+    
 1. Select **Add and configure** and wait for the tool to be added. The tool is now listed in the Product Support agent's **Tools**.
 
     ![Screenshot of the Product Support agent's Tools section, listing the Marketing Pitch Prompt tool.](../Media/agent-updated-tools.png)

--- a/Instructions/Labs/03-Connector-actions/01-create-connector-action.md
+++ b/Instructions/Labs/03-Connector-actions/01-create-connector-action.md
@@ -18,6 +18,7 @@ This exercise should take approximately **15** minutes to complete.
 This exercise focuses on adding connector tools to an existing agent. This exercise assumes the following:
 
 1. You've already created a **Product Support** declarative agent in Copilot Studio. If you need instructions for creating a declarative agent, see: [Create a declarative agent](../01-Build-your-first-declarative-agent/01-create-declarative-agent.md).
+
 1. You have a SharePoint site titled **Product Support** that contains a document library named **Products** containing files with sample product-related data. For instructions, see the section titled **Before you start** within the exercise: [Add custom knowledge](../01-Build-your-first-declarative-agent/02-add-custom-knowledge.md).
 
 ## Create a SharePoint connector tool from a prebuilt connector
@@ -39,12 +40,15 @@ Create a connector tool using the SharePoint List Folder prebuilt connector and 
 1. Browse and select the **List Folder** SharePoint connector.
 
     ![Screenshot of the Add tool window highlighting the List folder connector.](../Media/add-tool-list-folder.png)
+
 1. The modal window displays a connection for the SharePoint connector. A green checkmark will be displayed next to the connector when your connection is active. You may select the **...** to view details about the connection. If the status is **Not connected**, select the dropdown next to **Not connected** and select **Create new connection**.
 
     ![Screenshot of the Add tool window highlighting the Create new connection button.](../Media/create-new-connection.png)
+
 1. On the **Connect to SharePoint** dialog, select **Connect directly (cloud services)**, then select **Create**.
 
 1. You will be prompted to sign in. Sign in using the M365 account you're using for the exercise.
+
 1. On the **Add tool** dialog, after a connection is established, select **Add and configure** to add the tool to your agent.
 
 1. Confirm that the **List folder - connector** tool is listed in the **Tools** section of your agent.
@@ -80,8 +84,11 @@ Configure the properties of the connector tool for the agent.
 Let's also update your agent's instructions, providing guidance to the agent for how to use the connector tool.
 
 1. Return to the overview page for your **Product Support** agent.
+
 1. From the **Details** section of your **Product Support** agent in Copilot Studio, select **Edit**.
+
 1. In the **Instructions** text box, add the following to the existing instructions text: `When asked about available support resources, use the SharePoint connector to list the files in the Products folder and let the user know the SharePoint Connector was used.`
+
 1. Select **Save**.
 
 ## Test your agent with the tool


### PR DESCRIPTION
## Summary

Corrects UI drift in the SharePoint document library creation steps in Lab 01 Exercise 02, where the portal now uses **+ New** instead of **Create** and groups the blank library option under a **Start from scratch or reuse** heading. Also adds blank lines between numbered steps across labs 01–03 so each step renders as its own list item and matches Microsoft Learn formatting conventions.

## Changes

### Lab 01 — Build your first declarative agent

- Updated the document library creation step: **Create** → **+ New**, and clarified that **Blank library** is found under the **Start from scratch or reuse** section on the **Create a new document library** page.
- Added blank lines between numbered steps in the agent creation, testing, publishing, and Microsoft 365 Copilot testing sections.
- Added blank lines between numbered steps in the SharePoint site setup, sample data upload, URL copy, knowledge configuration, and agent testing sections.
- Added blank lines between numbered steps in the suggested prompts and publishing sections.

### Lab 02 — Prompt actions

- Added blank lines between numbered steps in the custom prompt creation, prompt testing, and optional prompt tool sections.

### Lab 03 — Connector actions

- Added blank lines between numbered steps in the prerequisites, connector tool creation, and agent instruction update sections.

## Files changed

- `Instructions/Labs/01-Build-your-first-declarative-agent/01-create-declarative-agent.md` — step spacing added throughout the exercise.
- `Instructions/Labs/01-Build-your-first-declarative-agent/02-add-custom-knowledge.md` — document library creation steps updated for current SharePoint UI (**+ New**, **Start from scratch or reuse**); step spacing added throughout.
- `Instructions/Labs/01-Build-your-first-declarative-agent/03-add-starter-prompts.md` — step spacing added in the suggested prompts and publish sections.
- `Instructions/Labs/02-Prompt-actions/01-create-prompt-action.md` — step spacing added in the prompt builder and prompt tool sections.
- `Instructions/Labs/03-Connector-actions/01-create-connector-action.md` — step spacing added in the prerequisites and connector configuration sections.