### PR TITLE
fix(lab00): correct media path casing in image links

### DIFF
--- a/Instructions/Labs/00-Setup/00-setup.md
+++ b/Instructions/Labs/00-Setup/00-setup.md
@@ -26,7 +26,7 @@ Before you start the lab exercises, you must create a development environment to
 
 1. Select the ellipses (**...**) for the **Contoso (default)** environment and select **Add Dataverse**.
 
-   ![Add Dataverse to the default environment in the Power Platform Admin center.](../media/add-dataverse.png)
+   ![Add Dataverse to the default environment in the Power Platform Admin center.](../Media/add-dataverse.png)
 
 1. Leave all of the default settings and select **Add**.
 
@@ -38,7 +38,7 @@ Before you start the lab exercises, you must create a development environment to
    - **Region**: default region
    - **Name**: *Your name*
    
-   ![Create an environment in the Power Platform Admin center.](../media/create-environment.png)
+   ![Create an environment in the Power Platform Admin center.](../Media/create-environment.png)
 
 1. Expand **Change default settings** and configure the following:
    - **Environment group**: None
@@ -58,7 +58,7 @@ Before you start the lab exercises, you must create a development environment to
 > [!NOTE]
 > Environment provisioning can take several minutes depending on tenant configuration.
 
-   ![Environment created in the Power Platform Admin center.](../media/environment-created.png)
+   ![Environment created in the Power Platform Admin center.](../Media/environment-created.png)
 
 5. In a new browser tab, navigate to `https://copilotstudio.microsoft.com/` and sign in if prompted.
 
@@ -79,6 +79,6 @@ Before you start the lab exercises, you must create a development environment to
 
 1. In the upper right corner of the page, switch environments by using the Environment Selector and select the environment you created.
 
-   ![Select your environment in the Copilot Studio.](../media/select-environment.png)
+   ![Select your environment in the Copilot Studio.](../Media/select-environment.png)
 
 You now have a Power Platform environment to work in.


### PR DESCRIPTION
## Summary

Four image references in the setup lab pointed to `../media/` (lowercase), but the
tracked folder in the repository is `Instructions/Labs/Media`. On case-sensitive
hosting the screenshots failed to render, leaving learners without the visual guidance
for provisioning their Power Platform environment. This PR corrects the casing so all
images resolve.

## Changes

- Updated the **Add Dataverse to the default environment** screenshot path to `../Media/add-dataverse.png`
- Updated the **Create a new environment** screenshot path to `../Media/create-environment.png`
- Updated the environment-created confirmation screenshot path to `../Media/environment-created.png`
- Updated the Copilot Studio environment selector screenshot path to `../Media/select-environment.png`

No instructional text, step order, or UI guidance was changed — this is a link-integrity
fix only.

## Files changed

- `Instructions/Labs/00-Setup/00-setup.md` — corrected 4 image link paths from `../media/` to `../Media/` to match the tracked folder casing